### PR TITLE
Changed SHA1 return raw output

### DIFF
--- a/itsdangerous.php
+++ b/itsdangerous.php
@@ -25,12 +25,12 @@ function int_to_bytes($num) {
         $output .= chr($num & 0xff);
         $num >>= 8;
     }
-    return $output;
+    return strrev($output);
 }
 
 function bytes_to_int($bytes) {
     $output = 0;
-    foreach(str_split(strrev($bytes)) as $byte) {
+    foreach(str_split($bytes) as $byte) {
         if($output > 0)
             $output <<= 8;
         $output += ord($byte);


### PR DESCRIPTION
This is to stay consistent with the python version.
It uses digest() rather than hexdigest().
This is crucial for PHP and Python applications using
itsdangerous to be compatible.

Also moved strrev()
