### PR TITLE
Fixed BadSignature error being caught

### DIFF
--- a/itsdangerous.php
+++ b/itsdangerous.php
@@ -196,18 +196,9 @@ class TimestampSigner extends Signer {
 
     public function unsign($value, $max_age=null, $return_timestamp=false) {
 
-        try {
-            $result = parent::unsign($value);
-            $sig_err = null;
-        } catch (BadSignature $ex) {
-            $sig_err = $ex;
-            $result = $ex->payload;
-        }
+        $result = parent::unsign($value);
 
         if(strpos($result, $this->sep) === false) {
-            if (!is_null($sig_err)) {
-                throw $sig_err;
-            }
             throw new BadTimeSignature("timestamp missing", $result);
         }
 


### PR DESCRIPTION
Bad signatures are being signed and validated when using TimestampSigner.

If a bad signature is passed, and there is a timestamp present in the signature, then no error is ever thrown.  
